### PR TITLE
WPengine fix

### DIFF
--- a/src/Vimeo/Vimeo.php
+++ b/src/Vimeo/Vimeo.php
@@ -468,7 +468,8 @@ class Vimeo
         }
 
         // To simplify the script we provide the filename as the text track name, but you can provide any value you want.
-        $name = array_slice(explode("/", $file_path), -1)[0];
+        $name = array_slice(explode("/", $file_path), -1);
+        $name = $name[0];
 
         $texttrack_response = $this->request($texttracks_uri, array('type' => $track_type, 'language' => $language, 'name' => $name), 'POST');
         if ($texttrack_response['status'] != 201) {


### PR DESCRIPTION
wpengine errors on $var = function()[0] saying `syntax error, unexpected '[' in src/Vimeo/Vimeo.php on line 461` I presume it's not the only host to do so, it's annoying, but a really easy fix.
