### PR TITLE
Change minimum stability to stable.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 			"homepage": "http://vimeo.com"
 		}
 	],
-	"minimum-stability": "dev",
+	"minimum-stability": "stable",
 	"require": {
 		"php": ">=5.3.0"
 	},


### PR DESCRIPTION
This defines the default behaviour for filtering packages by stability. This defaults to stable, so if you rely on a dev package, you should specify it in your file to avoid surprises. [More information.](https://getcomposer.org/doc/04-schema.md#minimum-stability)
