### PR TITLE
Certificate fallback (#23)

### DIFF
--- a/src/Vimeo/Vimeo.php
+++ b/src/Vimeo/Vimeo.php
@@ -141,6 +141,13 @@ class Vimeo
         $curl = curl_init($url);
         curl_setopt_array($curl, $curl_opts);
         $response = curl_exec($curl);
+
+        // Provide a CA certificate if needed.
+        if (curl_errno($curl) == 60) {
+            curl_setopt($curl, CURLOPT_CAINFO, dirname(__FILE__) . '/ca.crt');
+            $response = curl_exec($curl);
+        }
+
         $curl_info = curl_getinfo($curl);
         curl_close($curl);
 

--- a/src/Vimeo/Vimeo.php
+++ b/src/Vimeo/Vimeo.php
@@ -143,7 +143,7 @@ class Vimeo
         $response = curl_exec($curl);
 
         // Provide a CA certificate if needed.
-        if (curl_errno($curl) == 60) {
+        if (curl_errno($curl) == CURLE_SSL_CACERT) {
             curl_setopt($curl, CURLOPT_CAINFO, dirname(__FILE__) . '/ca.crt');
             $response = curl_exec($curl);
         }


### PR DESCRIPTION
This is just a small fix that checks if certificate validation fails and provides the api.vimeo.com CA certificate as a fallback. In order for it to work, the CA certificate has to be present at `src/Vimeo/ca.crt` (I didn't add it per your earlier concerns about non-staff members adding certificate code).