### PR TITLE
Simple Cachable (TTL style) replacement class for Vimeo/Vimeo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
+.idea
 vendor
 config.json

--- a/src/Vimeo/Cachable/AbstractInterface.php
+++ b/src/Vimeo/Cachable/AbstractInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Vimeo\Cachable;
+
+abstract class AbstractInterface {
+  abstract function cachableInterfaceUniqueName($parts);
+  abstract function cachableRequiresRefresh($ttl, $uniqueName);
+  abstract function cachableSetData($uniqueName, $in, $newTime=NULL);
+  abstract function cachableGetData($uniqueName);
+}

--- a/src/Vimeo/Cachable/Factory/FileSystem.php
+++ b/src/Vimeo/Cachable/Factory/FileSystem.php
@@ -1,0 +1,49 @@
+<?php
+  /**
+   * Created by PhpStorm.
+   * User: Carl
+   * Date: 03/01/2015
+   * Time: 03:20
+   */
+
+  namespace Vimeo\Cachable\Factory;
+
+  use Vimeo;
+
+  class FileSystem extends Vimeo\Cachable\AbstractInterface {
+
+    var $cacheDirectory = './';
+
+    function __construct($cacheDirectory = './') {
+      $this->cacheDirectory = $cacheDirectory;
+      if(!is_dir($this->cacheDirectory)) {
+        throw new \Exception('Please create the requested cache directory and make sure it is writable.');
+      }
+    }
+
+    function cachableInterfaceUniqueName($parts) {
+      return $this->cacheDirectory . DIRECTORY_SEPARATOR . md5(implode('++', $parts)) . '.cache';
+    }
+
+    function cachableRequiresRefresh($ttl, $uniqueName) {
+      if (file_exists($uniqueName)) {
+        $t = filemtime($uniqueName);
+        /** @noinspection PhpWrongStringConcatenationInspection */
+        if ($t + $ttl < time()) {
+          return TRUE;
+        }
+
+        return FALSE;
+      }
+
+      return TRUE;
+    }
+
+    function cachableSetData($uniqueName, $in, $newTime = NULL) {
+      file_put_contents($uniqueName, serialize($in));
+    }
+
+    function cachableGetData($uniqueName) {
+      return unserialize(file_get_contents($uniqueName));
+    }
+  }

--- a/src/Vimeo/Cachable/Factory/FileSystemAndSessions.php
+++ b/src/Vimeo/Cachable/Factory/FileSystemAndSessions.php
@@ -1,0 +1,59 @@
+<?php
+  /**
+   * Created by PhpStorm.
+   * User: Carl
+   * Date: 03/01/2015
+   * Time: 03:20
+   */
+
+  namespace Vimeo\Cachable\Factory;
+
+  use Vimeo;
+
+  class FileSystemAndSessions extends Vimeo\Cachable\AbstractInterface {
+
+    var $fileSystem = NULL;
+    var $session = NULL;
+
+    function __construct($cachableDirectory = './') {
+      $this->fileSystem = new FileSystem($cachableDirectory);
+      $this->session = new Sessions();
+    }
+
+    function translateToSession($in) {
+      return 'fs2s' . md5($in);
+    }
+
+    function cachableInterfaceUniqueName($parts) {
+      return $this->fileSystem->cachableInterfaceUniqueName($parts);
+    }
+
+    function cachableRequiresRefresh($ttl, $uniqueName) {
+      //Check session first, return FALSE if session is has not expired TTL
+      $r1 = $this->session->cachableRequiresRefresh($ttl, $this->translateToSession($uniqueName));
+      if ($r1 === FALSE) {
+        return FALSE;
+      }
+
+      //Session cache apparently failed, but does the filesystem have it?
+      $r2 = $this->fileSystem->cachableRequiresRefresh($ttl, $uniqueName);
+      if ($r2 === FALSE) {
+        //The file system is Ok, copy the data back into session
+        $this->session->cachableSetData($this->translateToSession($uniqueName), $this->fileSystem->cachableGetData($uniqueName), filemtime($uniqueName));
+
+        return FALSE;
+      }
+
+      return TRUE;
+    }
+
+    function cachableSetData($uniqueName, $in, $newTime = NULL) {
+      $this->fileSystem->cachableSetData($uniqueName, $in);
+      $this->session->cachableSetData($this->translateToSession($uniqueName), $in);
+    }
+
+    function cachableGetData($uniqueName) {
+      return $this->session->cachableGetData($this->translateToSession($uniqueName));
+    }
+
+  }

--- a/src/Vimeo/Cachable/Factory/Sessions.php
+++ b/src/Vimeo/Cachable/Factory/Sessions.php
@@ -1,0 +1,55 @@
+<?php
+  /**
+   * Created by PhpStorm.
+   * User: Carl
+   * Date: 03/01/2015
+   * Time: 03:20
+   */
+
+  namespace Vimeo\Cachable\Factory;
+
+  use Vimeo;
+
+  class Sessions extends Vimeo\Cachable\AbstractInterface {
+
+    const SESSION_KEY_CORE = 'vimeoCachableData';
+    const SESSION_KEY_LAST_SAVED = 'vimeoLastSaved';
+    const SESSION_KEY_STORAGE = 'vimeoStorage';
+
+    function __construct() {
+      //Sanity Checks
+      if (!isset($_SESSION[static::SESSION_KEY_CORE])) {
+        $_SESSION[static::SESSION_KEY_CORE] = array(static::SESSION_KEY_LAST_SAVED => array(), static::SESSION_KEY_STORAGE => array());
+      }
+      if (!is_array($_SESSION[static::SESSION_KEY_CORE])) {
+        $_SESSION[static::SESSION_KEY_CORE] = array(static::SESSION_KEY_LAST_SAVED => array(), static::SESSION_KEY_STORAGE => array());
+      }
+      if (!isset($_SESSION[static::SESSION_KEY_CORE][static::SESSION_KEY_LAST_SAVED])) {
+        $_SESSION[static::SESSION_KEY_CORE][static::SESSION_KEY_LAST_SAVED] = array();
+      }
+      if (!isset($_SESSION[static::SESSION_KEY_CORE][static::SESSION_KEY_STORAGE])) {
+        $_SESSION[static::SESSION_KEY_CORE][static::SESSION_KEY_STORAGE] = array();
+      }
+    }
+
+    function cachableInterfaceUniqueName($parts) {
+      return 'vimeo' . md5(implode('++', $parts));
+    }
+
+    function cachableRequiresRefresh($ttl, $uniqueName) {
+      if (!isset($_SESSION[static::SESSION_KEY_CORE][static::SESSION_KEY_STORAGE][$uniqueName])) return TRUE;
+      if (!isset($_SESSION[static::SESSION_KEY_CORE][static::SESSION_KEY_LAST_SAVED][$uniqueName])) return TRUE;
+      if ($_SESSION[static::SESSION_KEY_CORE][static::SESSION_KEY_LAST_SAVED][$uniqueName] + $ttl < time()) return TRUE;
+
+      return FALSE;
+    }
+
+    function cachableSetData($uniqueName, $in, $newTime = NULL) {
+      $_SESSION[static::SESSION_KEY_CORE][static::SESSION_KEY_STORAGE][$uniqueName] = $in;
+      $_SESSION[static::SESSION_KEY_CORE][static::SESSION_KEY_LAST_SAVED][$uniqueName] = ($newTime === NULL) ? time() : $newTime;
+    }
+
+    function cachableGetData($uniqueName) {
+      return $_SESSION[static::SESSION_KEY_CORE][static::SESSION_KEY_STORAGE][$uniqueName];
+    }
+  }

--- a/src/Vimeo/VimeoCachable.php
+++ b/src/Vimeo/VimeoCachable.php
@@ -1,0 +1,64 @@
+<?php
+
+  namespace Vimeo;
+
+  class VimeoCachable extends Vimeo {
+
+    //Magic numbers...
+    const CACHE_1_MINUTE = 60;
+    const CACHE_1_HOUR = 3600;
+    const CACHE_1_DAY = 86400;
+    const CACHE_15_DAYS = 1296000;
+    const CACHE_30_DAYS = 2592000;
+    const CACHE_45_DAYS = 3888000;
+    const CACHE_60_DAYS = 5184000;
+    const CACHE_120_DAYS = 10368000;
+    const CACHE_365_DAYS = 31536000;
+
+    /** @var Cachable\AbstractInterface */
+    private $cachableInterface = NULL;
+
+    //Default to 60 seconds
+    private $cachableDefaultTTL = 60;
+
+    /**
+     * @param int $cachableDefaultTTL
+     */
+    public function setDefaultTTL($cachableDefaultTTL) {
+      $this->cachableDefaultTTL = $cachableDefaultTTL;
+    }
+
+    public function setCachableInterface(Cachable\AbstractInterface $instance) {
+      $this->cachableInterface = $instance;
+    }
+
+    public function requestWithTTL($ttl, $url, $params = array(), $method = 'GET', $json_body = TRUE) {
+      $chain = array();
+      $chain[] = serialize($this->buildAuthorizationEndpoint(''));
+      $chain[] = serialize($this->getToken());
+      $chain[] = serialize($url);
+      $chain[] = serialize($params);
+      $chain[] = serialize($method);
+      $chain[] = serialize($json_body);
+
+      //Fallback to non-cachable when not assigned to an instance to use.
+      if ($this->cachableInterface === NULL) {
+        return parent::request($url, $params, $method, $json_body);
+      }
+
+      $uniqueNameFromCachableInterface = $this->cachableInterface->cachableInterfaceUniqueName($chain);
+      if ($this->cachableInterface->cachableRequiresRefresh($ttl, $uniqueNameFromCachableInterface)) {
+        $result = parent::request($url, $params, $method, $json_body);
+        $this->cachableInterface->cachableSetData($uniqueNameFromCachableInterface, $result);
+
+        return $result;
+      } else {
+        return $this->cachableInterface->cachableGetData($uniqueNameFromCachableInterface);
+      }
+    }
+
+    public function request($url, $params = array(), $method = 'GET', $json_body = TRUE) {
+      //Use the new function, with the default TTL given
+      return $this->requestWithTTL($this->cachableDefaultTTL, $url, $params, $method, $json_body);
+    }
+  }


### PR DESCRIPTION
A simple replacement class to allow TTL style caching for API calls.
```
$lib = new \Vimeo\VimeoCachable(... , ...);
```
You can then use the prefabricated classes that support storage in either, PHP sessions (__Vimeo\Cachable\Factory\Sessions__), file systems (__Vimeo\Cachable\Factory\FileSystem__), or a hybrid of the two (__Vimeo\Cachable\Factory\FileSystemAndSessions__, where sessions is the primary cache and is backed up by the file system).  Simply passing an instance of the class will do.  For example;
```
$lib->setCachableInterface( new Vimeo\Cachable\Factory\FileSystemAndSessions('../../cache') );
```
_Note:  You must create the cache directory first and must be writable if you are using the file system._

By default, the TTL is set to 60 seconds.  You can change this by using __$lib->setDefaultTTL(...)__ or by setting the TTL on every request by providing the TTL seconds in the first parameter via __$lib->requestWithTTL( 3600, ..... )__.  Parameters are the same as __request__ there-after, for example
```
$json = $lib->request(3600, '/videos/123456789/pictures');
```