### PR TITLE
Remove unexisting machine_id param

### DIFF
--- a/src/Vimeo/Vimeo.php
+++ b/src/Vimeo/Vimeo.php
@@ -291,7 +291,7 @@ class Vimeo
      * @throws VimeoUploadException
      * @return array Status
      */
-    public function upload($file_path, $upgrade_to_1080 = false, $machine_id = null)
+    public function upload($file_path, $upgrade_to_1080 = false)
     {
         // Validate that our file is real.
         if (!is_file($file_path)) {
@@ -300,9 +300,6 @@ class Vimeo
 
         // Begin the upload request by getting a ticket
         $ticket_args = array('type' => 'streaming', 'upgrade_to_1080' => $upgrade_to_1080);
-        if ($machine_id !== null) {
-            $ticket_args['machine_id'] = $machine_id;
-        }
         $ticket = $this->request('/me/videos', $ticket_args, 'POST');
 
         return $this->perform_upload($file_path, $ticket);
@@ -317,7 +314,7 @@ class Vimeo
      * @throws VimeoUploadException
      * @return array Status
      */
-    public function replace($video_uri, $file_path, $upgrade_to_1080 = false, $machine_id = null)
+    public function replace($video_uri, $file_path, $upgrade_to_1080 = false
     {
         //  Validate that our file is real.
         if (!is_file($file_path)) {
@@ -328,9 +325,6 @@ class Vimeo
 
         // Begin the upload request by getting a ticket
         $ticket_args = array('type' => 'streaming', 'upgrade_to_1080' => $upgrade_to_1080);
-        if ($machine_id !== null) {
-            $ticket_args['machine_id'] = $machine_id;
-        }
         $ticket = $this->request($uri, $ticket_args, 'PUT');
 
         return $this->perform_upload($file_path, $ticket);


### PR DESCRIPTION
Both [`/me/videos`](https://developer.vimeo.com/api/endpoints/me#/videos) and [`/videos/{uri}/files`](https://developer.vimeo.com/api/endpoints/videos#/{video_id}/files) endpoints doesn't deal with a `machine_id` parameter.

If merged, this should be tagget as 1.1.1, as it doesn't introduce any BC break (calling `upload('foo.mp4', true, 1234)` won't raise any error).