### PR TITLE
Remove contributors from the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,16 +222,10 @@ If you have any additional questions or problems, create a [ticket](https://gith
 # Framework Integrations
  - **Wordpress** - http://vimeography.com/
  - **Laravel** - https://github.com/vinkla/vimeo
-
+ 
 If you have integrated Vimeo into a popular PHP framework let us know!
 
-
 # Contributors
-- [dashron](https://github.com/dashron)
-- [sclm](https://github.com/sclm)
-- [greedo](https://github.com/greedo)
-- [sgmendez](https://github.com/sgmendez) ([32e4d7753a66e71dd158bf55b8a4b30ed564ef30](https://github.com/vimeo/vimeo.php/commit/32e4d7753a66e71dd158bf55b8a4b30ed564ef30))
-- [vinkla](https://github.com/vinkla) ([033a43156d6adae9e5757aefbfcf67c9ecdc605c](https://github.com/vimeo/vimeo.php/commit/033a43156d6adae9e5757aefbfcf67c9ecdc605c))
-- [majna](https://github.com/majna) (documentation improvements)
-- [videoMonkey](https://github.com/videoMonkey) ([759e81a664e90d1f5249cea0eda843b1a6619090](https://github.com/vimeo/vimeo.php/commit/759e81a664e90d1f5249cea0eda843b1a6619090))
-- [dstelljes](https://github.com/dstelljes) ([935f304ed7ba87a4d6b4239f6d50c633227a9d18](https://github.com/vimeo/vimeo.php/commit/935f304ed7ba87a4d6b4239f6d50c633227a9d18))
+
+To see the contributors please visit the [contributors graph](https://github.com/vimeo/vimeo.php/graphs/contributors).
+


### PR DESCRIPTION
They are already listed under https://github.com/vimeo/vimeo.php/graphs/contributors If you use GitHub then you know where to find the contributors, no need to list them twice.