### PR TITLE
Add bash installation example instead of json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,10 @@ array('privacy' => array('view' => 'disable'));
 
 ### Composer
 
-1. Add the vimeo library to your composer.json file's require field
+1. Require this package, with [Composer](https://getcomposer.org/), in the root directory of your project.
 
-```json
-{
-	"require" : {
-		"vimeo/vimeo-api" : "1.1.*"
-	}
-}
+```bash
+composer require vimeo/vimeo-api
 ```
 
 2. Use the library `$lib = new \Vimeo\Vimeo($client_id, $client_secret)`


### PR DESCRIPTION
This has become quite common with composer and php packages. Instead of specifying a version composer will add the library and the latest version to the `composer.json` required array by itself.