### PR TITLE
Update README to include Single-User Auth Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ $lib->setToken($token->access_token)
 ### Authenticated
 
 
+#### Single User Applications
+
+If you only ever plan on interacting with a single user account feel free to hard code your access tokens into your app. This token should follow the spec described under authenticated requests.
+
+If this user is also the app owner, you can generate a token on your app page.
+
+```php
+$lib->setToken($access_token);
+```
+
+#### Multi-User Applications
+
 1. Build a link to Vimeo so your users can authorize your app.
 
 ```php


### PR DESCRIPTION
I just upgraded to the V3 API (very nice job), but I was a little confused on authenticating. I only ever needed to authenticate as a single user, and thus didn't need to go through the hassle of building multi-user authentication. This information wasn't in this repo, so I had to go digging and found out about single-user auth on the Vimeo documentation on the API site.

I feel like this is probably a common enough occurance to warrant placing it in the readme. I retrieved all text from the Vimeo API site.