### PR TITLE
Allowed to performed conditional requests

### DIFF
--- a/src/Vimeo/Vimeo.php
+++ b/src/Vimeo/Vimeo.php
@@ -73,7 +73,7 @@ class Vimeo
      * @param bool $json_body
      * @return array This array contains three keys, 'status' is the status code, 'body' is an object representation of the json response body, and headers are an associated array of response headers
      */
-    public function request($url, $params = array(), $method = 'GET', $json_body = true)
+    public function request($url, $params = array(), $method = 'GET', $json_body = true, $last_modified = null)
     {
         // add accept header hardcoded to version 3.0
         $headers[] = 'Accept: ' . self::VERSION_STRING;
@@ -86,6 +86,10 @@ class Vimeo
         else {
             //  this may be a call to get the tokens, so we add the client info.
             $headers[] = 'Authorization: Basic ' . $this->_authHeader();
+        }
+
+        if ($last_modified) {
+            $headers[] = 'If-Modified-Since: ' . $last_modified;
         }
 
         //  Set the methods, determine the URL that we should actually request and prep the body.


### PR DESCRIPTION
This would speed up processes using the Vimeo API as long as save some bandwidth and CPU on Vimeo's side.

Right now, this is impossible to achieve as there's no control over the headers sent by the client.
