### PR TITLE
Allow providing custom http headers

### DIFF
--- a/src/Vimeo/Vimeo.php
+++ b/src/Vimeo/Vimeo.php
@@ -73,19 +73,20 @@ class Vimeo
      * @param bool $json_body
      * @return array This array contains three keys, 'status' is the status code, 'body' is an object representation of the json response body, and headers are an associated array of response headers
      */
-    public function request($url, $params = array(), $method = 'GET', $json_body = true)
+    public function request($url, $params = array(), $method = 'GET', $json_body = true, array $headers = array())
     {
-        // add accept header hardcoded to version 3.0
-        $headers[] = 'Accept: ' . self::VERSION_STRING;
-        $headers[] = 'User-Agent: ' . self::USER_AGENT;
+        $headers = array_merge(array(
+            'Accept' => self::VERSION_STRING,
+            'User-Agent' => self::USER_AGENT,
+        ), $headers);
 
         // add bearer token, or client information
         if (!empty($this->_access_token)) {
-            $headers[] = 'Authorization: Bearer ' . $this->_access_token;
+            $headers['Authorization'] = 'Bearer ' . $this->_access_token;
         }
         else {
             //  this may be a call to get the tokens, so we add the client info.
-            $headers[] = 'Authorization: Basic ' . $this->_authHeader();
+            $headers['Authorization'] = 'Basic ' . $this->_authHeader();
         }
 
         //  Set the methods, determine the URL that we should actually request and prep the body.
@@ -106,7 +107,7 @@ class Vimeo
             case 'PUT' :
             case 'DELETE' :
                 if ($json_body && !empty($params)) {
-                    $headers[] = 'Content-Type: application/json';
+                    $headers['Content-Type'] = 'application/json';
                     $body = json_encode($params);
                 } else {
                     $body = http_build_query($params, '', '&');
@@ -122,7 +123,9 @@ class Vimeo
         }
 
         // Set the headers
-        $curl_opts[CURLOPT_HTTPHEADER] = $headers;
+        foreach ($headers as $key => $value) {
+            $curl_opts[CURLOPT_HTTPHEADER][] = sprintf('%s: %s', $key, $value);
+        }
 
         $response = $this->_request($curl_url, $curl_opts);
 


### PR DESCRIPTION
This PR intends to allow providing custom headers when performing requests.

This is especially useful to perform conditionnal requests through `If-Modified-Since`, requests against older API version through `Accept` or any other requests requiring custom headers.

It covers the technical need covered by https://github.com/vimeo/vimeo.php/pull/101.

FYI, this feature is already implemented in the javascript client: https://github.com/vimeo/vimeo.js/blob/master/lib/vimeo.js#L220.
