### PR TITLE
Correctly handle response headers parsing

### DIFF
--- a/src/Vimeo/Vimeo.php
+++ b/src/Vimeo/Vimeo.php
@@ -213,7 +213,7 @@ class Vimeo
         $http = array_shift($list);
 
         foreach ($list as $header) {
-            $parts = explode(':', $header);
+            $parts = explode(':', $header, 2);
             $final_headers[trim($parts[0])] = isset($parts[1]) ? trim($parts[1]) : '';
         }
 


### PR DESCRIPTION
This fixes the incorrect parsing of the headers containing a colon, e.g.

```X-RateLimit-Reset: 2016-08-29T17:31:12+00:00```