### PR TITLE
Allow providing custom HTTP headers

### DIFF
--- a/src/Vimeo/Vimeo.php
+++ b/src/Vimeo/Vimeo.php
@@ -72,6 +72,7 @@ class Vimeo
      * @param array $params An array of parameters to send to the endpoint. If the HTTP method is GET, they will be added to the url, otherwise they will be written to the body
      * @param string $method The HTTP Method of the request
      * @param bool $json_body
+     * @param array $headers An array of HTTP headers to pass along with the request.
      * @return array This array contains three keys, 'status' is the status code, 'body' is an object representation of the json response body, and headers are an associated array of response headers
      */
     public function request($url, $params = array(), $method = 'GET', $json_body = true, array $headers = array())


### PR DESCRIPTION
Props to @gquemener for initial PR
--
This PR intends to allow providing custom headers when performing requests.

This is especially useful to perform conditionnal requests through If-Modified-Since, requests against older API version through Accept or any other requests requiring custom headers.

It covers the technical need covered by #101.

FYI, this feature is already implemented in the javascript client: https://github.com/vimeo/vimeo.js/blob/master/lib/vimeo.js#L220.