### PR TITLE
Initialize the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: php
 
+dist: 'precise'
+
 php:
   - '5.3'
   - '5.4'
+  - '5.5'
   - '5.6'
   - '7.0'
   - '7.1'
@@ -15,4 +18,7 @@ install:
   - composer install
 
 script:
-  - vendor/bin/phpunit
+  - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+
+after_success:
+  - travis_retry vendor/bin/coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,14 @@
             "Vimeo\\": "src/Vimeo"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Vimeo\\VimeoTest\\": "tests/Vimeo"
+        }
+    },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8",
+        "php-coveralls/php-coveralls": "^1.0"
     },
     "scripts": {
         "coverage": "phpunit --coverage-html reports/",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/src/Vimeo/Vimeo.php
+++ b/src/Vimeo/Vimeo.php
@@ -158,6 +158,16 @@ class Vimeo
     }
 
     /**
+     * Gets custom cURL options.
+     *
+     * @return string
+     */
+    public function getCURLOptions()
+    {
+        return $this->_curl_opts;
+    }
+
+    /**
      * Sets custom cURL options.
      *
      * @param array $curl_opts An associative array of cURL options.

--- a/tests/Vimeo/VimeoTest.php
+++ b/tests/Vimeo/VimeoTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace Vimeo\VimeoTest;
 
-use Vimeo\Vimeo;
 use PHPUnit\Framework\TestCase;
+use Vimeo\Vimeo;
 
 class VimeoTest extends TestCase
 {
@@ -18,7 +18,7 @@ class VimeoTest extends TestCase
         $result = $vimeo->request('/users/userwillnotbefound');
 
         // Assert
-        $this->assertSame('You must provide a valid authenticated access token.', $result['body']['error']); 
+        $this->assertSame('You must provide a valid authenticated access token.', $result['body']['error']);
     }
 
     public function testRequestGetUserInformationWithAccessToken()

--- a/tests/Vimeo/VimeoTest.php
+++ b/tests/Vimeo/VimeoTest.php
@@ -64,10 +64,11 @@ class VimeoTest extends TestCase
 
         // Act
         $vimeo->setCurlOptions(array('custom_name' => 'custom_value'));
+        $result = $vimeo->getCurlOptions();
 
         // Assert
-        $this->assertInternalType('array', $vimeo->getCurlOptions());
-        $this->assertSame('custom_value', $vimeo->getCurlOptions()['custom_name']);
+        $this->assertInternalType('array', $result);
+        $this->assertSame('custom_value', $result['custom_name']);
     }
 
     public function testAccessTokenWithCallingFakeRedirectUri()

--- a/tests/Vimeo/VimeoTest.php
+++ b/tests/Vimeo/VimeoTest.php
@@ -101,7 +101,7 @@ class VimeoTest extends TestCase
         $vimeo = new Vimeo($this->clientId, $this->clientSecret);
 
         // Act
-        $result = $vimeo->clientCredentials(['public']);
+        $result = $vimeo->clientCredentials(array('public'));
 
         // Assert
         $this->assertSame('You must provide a valid authenticated access token.', $result['body']['error']);
@@ -137,7 +137,7 @@ class VimeoTest extends TestCase
         $vimeo = new Vimeo($this->clientId, $this->clientSecret);
 
         // Act
-        $result = $vimeo->buildAuthorizationEndpoint('https://fake.redirect.uri', ['public', 'private']);
+        $result = $vimeo->buildAuthorizationEndpoint('https://fake.redirect.uri', array('public', 'private'));
 
         // Assert
         $this->assertSame('https://api.vimeo.com/oauth/authorize?response_type=code&client_id=client_id&redirect_uri=https%3A%2F%2Ffake.redirect.uri&scope=public+private', $result);
@@ -149,7 +149,7 @@ class VimeoTest extends TestCase
         $vimeo = new Vimeo($this->clientId, $this->clientSecret);
 
         // Act
-        $result = $vimeo->buildAuthorizationEndpoint('https://fake.redirect.uri', ['public'], 'fake_state');
+        $result = $vimeo->buildAuthorizationEndpoint('https://fake.redirect.uri', array('public'), 'fake_state');
 
         // Assert
         $this->assertSame('https://api.vimeo.com/oauth/authorize?response_type=code&client_id=client_id&redirect_uri=https%3A%2F%2Ffake.redirect.uri&scope=public&state=fake_state', $result);

--- a/tests/Vimeo/VimeoTest.php
+++ b/tests/Vimeo/VimeoTest.php
@@ -1,0 +1,252 @@
+<?php
+namespace Vimeo\VimeoTest;
+
+use Vimeo\Vimeo;
+use PHPUnit\Framework\TestCase;
+
+class VimeoTest extends TestCase
+{
+    protected $clientId = 'client_id';
+    protected $clientSecret = 'client_secret';
+
+    public function testRequestGetUserInformation()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $result = $vimeo->request('/users/userwillnotbefound');
+
+        // Assert
+        $this->assertSame('You must provide a valid authenticated access token.', $result['body']['error']); 
+    }
+
+    public function testRequestGetUserInformationWithAccessToken()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret, 'fake_access_token');
+
+        // Act
+        $result = $vimeo->request('/users/userwillnotbefound');
+
+        // Assert
+        $this->assertSame('You must provide a valid authenticated access token.', $result['body']['error']);
+    }
+
+    public function testRequestGetUserInformationWithParams()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $result = $vimeo->request('/users/userwillnotbefound', array('fake_key=fake_value'));
+
+        // Assert
+        $this->assertSame('You must provide a valid authenticated access token.', $result['body']['error']);
+    }
+
+    public function testGetToken()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $vimeo->setToken('fake_access_token');
+
+        // Assert
+        $this->assertSame('fake_access_token', $vimeo->getToken());
+    }
+
+    public function testGetCurlOptions()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $vimeo->setCurlOptions(array('custom_name' => 'custom_value'));
+
+        // Assert
+        $this->assertInternalType('array', $vimeo->getCurlOptions());
+        $this->assertSame('custom_value', $vimeo->getCurlOptions()['custom_name']);
+    }
+
+    public function testAccessTokenWithCallingFakeRedirectUri()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $result = $vimeo->accessToken('fake_auth_code', 'https://fake.redirect.uri');
+
+        // Assert
+        $this->assertSame('invalid_client', $result['body']['error']);
+    }
+
+    public function testClientCredentialsWithDefaultScope()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $result = $vimeo->clientCredentials();
+
+        // Assert
+        $this->assertSame('You must provide a valid authenticated access token.', $result['body']['error']);
+    }
+
+    public function testClientCredentialsWithArrayScope()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $result = $vimeo->clientCredentials(['public']);
+
+        // Assert
+        $this->assertSame('You must provide a valid authenticated access token.', $result['body']['error']);
+    }
+
+    public function testBuildAuthorizationEndpointWithDefaultScopeAndNullState()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $result = $vimeo->buildAuthorizationEndpoint('https://fake.redirect.uri');
+
+        // Assert
+        $this->assertSame('https://api.vimeo.com/oauth/authorize?response_type=code&client_id=client_id&redirect_uri=https%3A%2F%2Ffake.redirect.uri&scope=public', $result);
+    }
+
+    public function testBuildAuthorizationEndpointWithNullScopeAndNullState()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $result = $vimeo->buildAuthorizationEndpoint('https://fake.redirect.uri', null);
+
+        // Assert
+        $this->assertSame('https://api.vimeo.com/oauth/authorize?response_type=code&client_id=client_id&redirect_uri=https%3A%2F%2Ffake.redirect.uri&scope=public', $result);
+    }
+
+    public function testBuildAuthorizationEndpointWithArrayScopeAndNullState()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $result = $vimeo->buildAuthorizationEndpoint('https://fake.redirect.uri', ['public', 'private']);
+
+        // Assert
+        $this->assertSame('https://api.vimeo.com/oauth/authorize?response_type=code&client_id=client_id&redirect_uri=https%3A%2F%2Ffake.redirect.uri&scope=public+private', $result);
+    }
+
+    public function testBuildAuthorizationEndpointWithArrayScopeAndState()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $result = $vimeo->buildAuthorizationEndpoint('https://fake.redirect.uri', ['public'], 'fake_state');
+
+        // Assert
+        $this->assertSame('https://api.vimeo.com/oauth/authorize?response_type=code&client_id=client_id&redirect_uri=https%3A%2F%2Ffake.redirect.uri&scope=public&state=fake_state', $result);
+    }
+
+    /**
+     * @expectedException Vimeo\Exceptions\VimeoUploadException
+     */
+    public function testUploadWithNonExistedFile()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $result = $vimeo->upload('./the_file_is_invalid');
+    }
+
+    /**
+     * @expectedException Vimeo\Exceptions\VimeoUploadException
+     */
+    public function testUploadWithFakeMachineIdShouldReturnVimeoRequestException()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $result = $vimeo->upload(__DIR__.'/../../composer.json', 'fake_machine_id');
+    }
+
+    /**
+     * @expectedException Vimeo\Exceptions\VimeoUploadException
+     */
+    public function testReplaceWithNonExistedFile()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $result = $vimeo->replace('https://vimeo.com/241711006', './the_file_is_invalid');
+    }
+
+    /**
+     * @expectedException Vimeo\Exceptions\VimeoRequestException
+     */
+    public function testReplaceWithVideoUriAndMachineIdShouldReturnVimeoRequestException()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $result = $vimeo->replace('https://vimeo.com/241711006', __DIR__.'/../../composer.json', 'fake_machine_id');
+    }
+
+    /**
+     * @expectedException Vimeo\Exceptions\VimeoUploadException
+     */
+    public function testUploadImageWithNonExistedFile()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $result = $vimeo->uploadImage('https://vimeo.com/241711006', './the_file_is_invalid');
+    }
+
+    /**
+     * @expectedException Vimeo\Exceptions\VimeoRequestException
+     */
+    public function testUploadImageWithPictureUriAndMachineIdShouldReturnVimeoRequestException()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $result = $vimeo->uploadImage('https://vimeo.com/user59081751', __DIR__.'/../../composer.json', 'fake_machine_id');
+    }
+
+    /**
+     * @expectedException Vimeo\Exceptions\VimeoUploadException
+     */
+    public function testuploadTexttrackWithNonExistedFile()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $result = $vimeo->uploadTexttrack('https://vimeo.com/241711006', './the_file_is_invalid', 'fake_track_type', 'zh_TW');
+    }
+
+    /**
+     * @expectedException Vimeo\Exceptions\VimeoRequestException
+     */
+    public function testuploadTexttrackWithPictureUriAndMachineIdShouldReturnVimeoRequestException()
+    {
+        // Arrange
+        $vimeo = new Vimeo($this->clientId, $this->clientSecret);
+
+        // Act
+        $result = $vimeo->uploadTexttrack('https://vimeo.com/user59081751', __DIR__.'/../../composer.json', 'fake_track_type', 'zh_TW');
+    }
+}


### PR DESCRIPTION
# Changed log
- Initialize the testings.
- Hook the coveralls code coverage service.
- According to the [issue](https://github.com/travis-ci/travis-ci/issues/7693), set the dist is precise to complete the PHP 5.3 testing.

BTW, if we test the upload functionalities testing really, we need to set the real client id and client secret.
Perhaps we can refer [this](https://docs.travis-ci.com/user/environment-variables/#Encrypted-Variables) to let id and secret being the encrypted environment variables.
What do you think?

Thanks.