### PR TITLE
Replacing our Tus upload integration with TusPHP.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,8 @@
 language: php
 
 php:
-  - '5.4'
-  - '5.5'
-  - '5.6'
-  - '7.0'
   - '7.1'
   - '7.2'
-
-matrix:
-  include:
-    - php: 5.3
-      dist: precise
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,10 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=7.1.0",
         "ext-curl": "*",
-        "ext-json":"*"
+        "ext-json":"*",
+        "ankitpokhrel/tus-php": "dev-master#460f00c14b774ec105dc840c61f229cc29c2f405"
     },
     "autoload": {
         "psr-4": {
@@ -27,8 +28,8 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8 || ^6.5",
-        "php-coveralls/php-coveralls": "^1.0"
+        "php-coveralls/php-coveralls": "^1.0",
+        "phpunit/phpunit": "^7.4"
     },
     "scripts": {
         "coverage": "phpunit --coverage-html reports/",

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,14 @@
     },
     "require-dev": {
         "php-coveralls/php-coveralls": "^1.0",
-        "phpunit/phpunit": "^7.4"
+        "phpunit/phpunit": "^7.4",
+        "vimeo/psalm": "^2.0"
     },
     "scripts": {
         "coverage": "phpunit --coverage-html reports/",
-        "tests": "phpunit"
+        "tests": [
+            "psalm",
+            "phpunit"
+        ]
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,8 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Vimeo PHP SDK">
             <directory>./tests/</directory>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<psalm useDocblockTypes="true">
+    <projectFiles>
+        <directory name="src" />
+        <directory name="tests/" />
+    </projectFiles>
+
+    <fileExtensions>
+        <extension name=".php" />
+    </fileExtensions>
+
+    <issueHandlers>
+        <!-- This hides a number of errors that we don't really care about. -->
+        <PropertyNotSetInConstructor>
+            <errorLevel type="suppress">
+                <directory name="tests/" />
+            </errorLevel>
+        </PropertyNotSetInConstructor>
+    </issueHandlers>
+</psalm>

--- a/src/Vimeo/Exceptions/VimeoException.php
+++ b/src/Vimeo/Exceptions/VimeoException.php
@@ -1,0 +1,9 @@
+<?php
+namespace Vimeo\Exceptions;
+
+/**
+ * VimeoException class for general failures.
+ */
+class VimeoException extends \Exception implements ExceptionInterface
+{
+}

--- a/tests/Vimeo/VimeoTest.php
+++ b/tests/Vimeo/VimeoTest.php
@@ -303,21 +303,21 @@ class VimeoTest extends TestCase
         $method->setAccessible(true);
 
         // The following cases result in < 1024 and as such should be allowed
-        $this->assertEquals(1, $method->invoke($client, 1, 1024));
-        $this->assertEquals(3, $method->invoke($client, 3, 1024));
+        $this->assertSame(1, $method->invoke($client, 1, 1024));
+        $this->assertSame(3, $method->invoke($client, 3, 1024));
 
         // A `chunk_size` larger than `file_size` is ok
-        $this->assertEquals(3, $method->invoke($client, 3, 1));
-        $this->assertEquals(1024, $method->invoke($client, 1024, 1));
+        $this->assertSame(3, $method->invoke($client, 3, 1));
+        $this->assertSame(1024, $method->invoke($client, 1024, 1));
 
         // A `chunk_size` <= 0 is equivalent to 1 byte.
-        $this->assertEquals(1, $method->invoke($client, 0, 1024));
-        $this->assertEquals(1, $method->invoke($client, -1000, 1024));
+        $this->assertSame(1, $method->invoke($client, 0, 1024));
+        $this->assertSame(1, $method->invoke($client, -1000, 1024));
 
         // The following cases all result in > 1024 chunks.
-        $this->assertEquals(2, $method->invoke($client, 1, 1025));
+        $this->assertSame(2, $method->invoke($client, 1, 1025));
 
         // 20 MB chunks for a 100000 MB file (100GB)
-        $this->assertEquals(102400001, $method->invoke($client, (20 * 1024 * 1024), (100000 * 1024 * 1024)));
+        $this->assertSame(102400001, $method->invoke($client, (20 * 1024 * 1024), (100000 * 1024 * 1024)));
     }
 }

--- a/tests/Vimeo/VimeoTest.php
+++ b/tests/Vimeo/VimeoTest.php
@@ -12,7 +12,7 @@ class VimeoTest extends TestCase
     /** @var string */
     protected $clientSecret = 'client_secret';
 
-    public function testRequestGetUserInformation()
+    public function testRequestGetUserInformation(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -26,7 +26,7 @@ class VimeoTest extends TestCase
         $this->assertSame('You must provide a valid authenticated access token.', $result['body']['error']);
     }
 
-    public function testRequestGetUserInformationWithAccessToken()
+    public function testRequestGetUserInformationWithAccessToken(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -40,7 +40,7 @@ class VimeoTest extends TestCase
         $this->assertSame('You must provide a valid authenticated access token.', $result['body']['error']);
     }
 
-    public function testRequestGetUserInformationWithParams()
+    public function testRequestGetUserInformationWithParams(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -54,7 +54,7 @@ class VimeoTest extends TestCase
         $this->assertSame('You must provide a valid authenticated access token.', $result['body']['error']);
     }
 
-    public function testGetToken()
+    public function testGetToken(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -68,7 +68,7 @@ class VimeoTest extends TestCase
         $this->assertSame('fake_access_token', $vimeo->getToken());
     }
 
-    public function testGetCurlOptions()
+    public function testGetCurlOptions(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -84,7 +84,7 @@ class VimeoTest extends TestCase
         $this->assertSame('custom_value', $result['custom_name']);
     }
 
-    public function testAccessTokenWithCallingFakeRedirectUri()
+    public function testAccessTokenWithCallingFakeRedirectUri(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -98,7 +98,7 @@ class VimeoTest extends TestCase
         $this->assertSame('invalid_client', $result['body']['error']);
     }
 
-    public function testClientCredentialsWithDefaultScope()
+    public function testClientCredentialsWithDefaultScope(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -112,7 +112,7 @@ class VimeoTest extends TestCase
         $this->assertSame('You must provide a valid authenticated access token.', $result['body']['error']);
     }
 
-    public function testClientCredentialsWithArrayScope()
+    public function testClientCredentialsWithArrayScope(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -126,7 +126,7 @@ class VimeoTest extends TestCase
         $this->assertSame('You must provide a valid authenticated access token.', $result['body']['error']);
     }
 
-    public function testBuildAuthorizationEndpointWithDefaultScopeAndNullState()
+    public function testBuildAuthorizationEndpointWithDefaultScopeAndNullState(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -140,7 +140,7 @@ class VimeoTest extends TestCase
         $this->assertSame('https://api.vimeo.com/oauth/authorize?response_type=code&client_id=client_id&redirect_uri=https%3A%2F%2Ffake.redirect.uri&scope=public', $result);
     }
 
-    public function testBuildAuthorizationEndpointWithNullScopeAndNullState()
+    public function testBuildAuthorizationEndpointWithNullScopeAndNullState(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -154,7 +154,7 @@ class VimeoTest extends TestCase
         $this->assertSame('https://api.vimeo.com/oauth/authorize?response_type=code&client_id=client_id&redirect_uri=https%3A%2F%2Ffake.redirect.uri&scope=public', $result);
     }
 
-    public function testBuildAuthorizationEndpointWithArrayScopeAndNullState()
+    public function testBuildAuthorizationEndpointWithArrayScopeAndNullState(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -168,7 +168,7 @@ class VimeoTest extends TestCase
         $this->assertSame('https://api.vimeo.com/oauth/authorize?response_type=code&client_id=client_id&redirect_uri=https%3A%2F%2Ffake.redirect.uri&scope=public+private', $result);
     }
 
-    public function testBuildAuthorizationEndpointWithArrayScopeAndState()
+    public function testBuildAuthorizationEndpointWithArrayScopeAndState(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -185,7 +185,7 @@ class VimeoTest extends TestCase
     /**
      * @expectedException Vimeo\Exceptions\VimeoUploadException
      */
-    public function testUploadWithNonExistedFile()
+    public function testUploadWithNonExistedFile(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -199,7 +199,7 @@ class VimeoTest extends TestCase
     /**
      * @expectedException Vimeo\Exceptions\VimeoUploadException
      */
-    public function testUploadWithInvalidParamShouldReturnVimeoRequestException()
+    public function testUploadWithInvalidParamShouldReturnVimeoRequestException(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -213,7 +213,7 @@ class VimeoTest extends TestCase
     /**
      * @expectedException Vimeo\Exceptions\VimeoUploadException
      */
-    public function testReplaceWithNonExistedFile()
+    public function testReplaceWithNonExistedFile(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -227,7 +227,7 @@ class VimeoTest extends TestCase
     /**
      * @expectedException Vimeo\Exceptions\VimeoUploadException
      */
-    public function testUploadImageWithNonExistedFile()
+    public function testUploadImageWithNonExistedFile(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -241,7 +241,7 @@ class VimeoTest extends TestCase
     /**
      * @expectedException Vimeo\Exceptions\VimeoUploadException
      */
-    public function testUploadTexttrackWithNonExistedFile()
+    public function testUploadTexttrackWithNonExistedFile(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -255,7 +255,7 @@ class VimeoTest extends TestCase
     /**
      * @expectedException Vimeo\Exceptions\VimeoRequestException
      */
-    public function testReplaceWithVideoUriShouldReturnVimeoRequestException()
+    public function testReplaceWithVideoUriShouldReturnVimeoRequestException(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -269,7 +269,7 @@ class VimeoTest extends TestCase
     /**
      * @expectedException Vimeo\Exceptions\VimeoRequestException
      */
-    public function testUploadImageWithPictureUriShouldReturnVimeoRequestException()
+    public function testUploadImageWithPictureUriShouldReturnVimeoRequestException(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 
@@ -283,7 +283,7 @@ class VimeoTest extends TestCase
     /**
      * @expectedException Vimeo\Exceptions\VimeoRequestException
      */
-    public function testUploadTexttrackWithPictureUriAndInvalidParamShouldReturnVimeoRequestException()
+    public function testUploadTexttrackWithPictureUriAndInvalidParamShouldReturnVimeoRequestException(): void
     {
         $this->markTestSkipped('Skipping until we have time to set up real tests with Travis secret storage.');
 


### PR DESCRIPTION
* [x] Replace our Tus upload integration with https://github.com/ankitpokhrel/tus-php.
* [x] Changes our PHP requirement from >=5.3.0 to >=7.1.0. Had to do this because tus-php requires 7.1+.
* [x] Loading [Psalm](https://github.com/vimeo/psalm) and setting it up to execute static analysis checks during the test process.

With these changes, I was able to upload video files that ranged from 13-793MB large. Since the default PHP memory limit is 128MB, we're uploading in 100MB chunks, so anything larger than what I've tested with should function just as well.

Since this is a breaking change, this'll be tagged released as v3.0.

Resolves https://github.com/vimeo/vimeo.php/issues/168