### PR TITLE
Locking ankitpokhrel/tus-php at v0.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=7.1.0",
         "ext-curl": "*",
         "ext-json":"*",
-        "ankitpokhrel/tus-php": "dev-master#460f00c14b774ec105dc840c61f229cc29c2f405"
+        "ankitpokhrel/tus-php": "v0.1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This locks our `ankitpokhrel/tus-php` dependency at v0.1.0. Attempting to lock at the `460f00c14b` commit didn't seem work properly as Composer would instead install `dev-master@HEAD`.

https://github.com/vimeo/vimeo.php/issues/189