### PR TITLE
update to stable tus-php, fix psalm warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=7.1.0",
         "ext-curl": "*",
         "ext-json":"*",
-        "ankitpokhrel/tus-php": "v0.1.0"
+        "ankitpokhrel/tus-php": "^v1.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Vimeo/VimeoTest.php
+++ b/tests/Vimeo/VimeoTest.php
@@ -80,7 +80,7 @@ class VimeoTest extends TestCase
         $result = $vimeo->getCurlOptions();
 
         // Assert
-        $this->assertInternalType('array', $result);
+        $this->assertIsArray($result);
         $this->assertSame('custom_value', $result['custom_name']);
     }
 


### PR DESCRIPTION
Closes #208
- upgraded tus-php to stable version v1.0 (some packages now have depend of carbon ^2.0, which is not allowed in the older tus-php versions)
- fixed psalm warning for deprecated method call `assertInternalType`

All tests pass, no linting issues, testing locally now.

Considering issue #189 I guess this update might break some functionality so I'd suggest 
- add the test case for the issue in #189
- do not tag the code in case you merge my PR unless some required adoptions will be incorporated (https://github.com/ankitpokhrel/tus-php/issues/159#issuecomment-498042923)