### PR TITLE
Enable a way to provide a custom configured Tus library.

### DIFF
--- a/src/Vimeo/Upload/TusClientFactory.php
+++ b/src/Vimeo/Upload/TusClientFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Vimeo\Upload;
+
+final class TusClientFactory implements TusClientFactoryInterface
+{
+
+	public function fromBaseUrl(string $baseUrl) : TusClient
+	{
+		return new TusClient($baseUrl);
+	}
+}

--- a/src/Vimeo/Upload/TusClientFactoryInterface.php
+++ b/src/Vimeo/Upload/TusClientFactoryInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Vimeo\Upload;
+
+interface TusClientFactoryInterface
+{
+	/**
+	 * Given a base URL, return a TusClient.
+	 */
+	public function fromBaseUrl(string $baseUrl) : TusClient;
+}


### PR DESCRIPTION
This PR gives the ability to provide a TusClient factory to the Vimeo client. When performing an upload action the factory is used to create a TusClient instead of having a tus client created directly in a private method.

The developer if wanting to inject their own factory would need to implement the factory interface provided in this PR and pass into the Vimeo client constructor.

This allows customization of the `TusClient` by users of the Vimeo api client. For example, the default caching behavior of the TusClient library is a FileStore that creates temporary files within the vendor include directory. In my case, it is not desirable to allow write access to that directory from php runtime.

Example use:

```php
<?php declare(strict_types = 1);

namespace My\Namespace;

use TusPhp\Cache\FileStore;
use Vimeo\Upload\TusClient;
use Vimeo\Upload\TusClientFactoryInterface;

class TusClientFactory implements TusClientFactoryInterface {

	/**
	 * @var \TusPhp\Cache\FileStore
	 */
	private $fileCache;

	/**
	 * Constructor.
	 */
	public function __construct() {
		$this->fileCache = new FileStore('/tmp');
	}

	/**
	 * Create a tus php client given a baes URL.
	 */
	public function fromBaseUrl(string $baseUrl) : TusClient {
		$client = new TusClient($baseUrl);
		$client->setCache($this->fileCache);
		return $client;
	}
}
```

Then, where I create a Vimeo client:

```php
$client = new Vimeo(
	'client_id', 
	'client_secret', 
	'access_token',
	new \My\Namespace\TusClientFactory()
);
```

A default implementation that does what the library did before has been implemented and is utilized when the developer does not provide it to the constructor.