### PR TITLE
add changelogs for 3.0.6-3.0.8, fix user agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Fixed
 - Fix an issue with SSL certificates on certain requests ([#286](https://github.com/vimeo/vimeo.php/issues/286))
 
-## [3.0.6] - 2019-12-11
+## [3.0.6] - 2020-06-20
 ### Fixed
 - Add TUS 2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 # Changelog
+## [3.0.8] - 2019-12-11
+### Fixed
+- Fix user-agent in vimeo.php
+
+## [3.0.7] - 2019-12-11
+### Fixed
+- Fix an issue with SSL certificates on certain requests ([#286](https://github.com/vimeo/vimeo.php/issues/286))
+
+## [3.0.6] - 2019-12-11
+### Fixed
+- Add TUS 2.0
+
 ## [3.0.5] - 2019-12-11
 ### Fixed
 - Fixes `setUrl` method not found error.([#239](https://github.com/vimeo/vimeo.php/pull/239)) 
@@ -117,6 +129,9 @@
 ### Added
 - This is the Vimeo library for version 3 of the Vimeo API.
 
+[3.0.8]: https://github.com/vimeo/vimeo.php/compare/3.0.7...3.0.8
+[3.0.7]: https://github.com/vimeo/vimeo.php/compare/3.0.6...3.0.7
+[3.0.6]: https://github.com/vimeo/vimeo.php/compare/3.0.5...3.0.6
 [3.0.5]: https://github.com/vimeo/vimeo.php/compare/3.0.4...3.0.5
 [3.0.4]: https://github.com/vimeo/vimeo.php/compare/3.0.3...3.0.4
 [3.0.3]: https://github.com/vimeo/vimeo.php/compare/3.0.2...3.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## [3.0.8] - 2019-12-11
+## [3.0.8] - 2021-05-03
 ### Fixed
 - Fix user-agent in vimeo.php
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Fixed
 - Fix user-agent in vimeo.php
 
-## [3.0.7] - 2019-12-11
+## [3.0.7] - 2021-04-28
 ### Fixed
 - Fix an issue with SSL certificates on certain requests ([#286](https://github.com/vimeo/vimeo.php/issues/286))
 

--- a/src/Vimeo/Vimeo.php
+++ b/src/Vimeo/Vimeo.php
@@ -35,7 +35,7 @@ class Vimeo
     const CLIENT_CREDENTIALS_TOKEN_ENDPOINT = '/oauth/authorize/client';
     const VERSIONS_ENDPOINT = '/versions';
     const VERSION_STRING = 'application/vnd.vimeo.*+json; version=3.4';
-    const USER_AGENT = 'vimeo.php 3.0.5; (http://developer.vimeo.com/api/docs)';
+    const USER_AGENT = 'vimeo.php 3.0.8; (http://developer.vimeo.com/api/docs)';
 
     /** @var array */
     protected $_curl_opts = array();


### PR DESCRIPTION
Versioning fixes
- Reflect v3.0.8 in the client's user agent (3.0.8 will be the version this is released under)
- Add changelogs for 3.0.5-3.0.8