### PR TITLE
Make perform_upload_tus() public. Useful for advanced usage.

### DIFF
--- a/src/Vimeo/Vimeo.php
+++ b/src/Vimeo/Vimeo.php
@@ -572,7 +572,7 @@ class Vimeo
      * @return string
      * @throws VimeoUploadException
      */
-    private function perform_upload_tus(string $file_path, $file_size, array $attempt): string
+    public function perform_upload_tus(string $file_path, $file_size, array $attempt): string
     {
         $default_chunk_size = (100 * 1024 * 1024); // 100 MB
 


### PR DESCRIPTION
This is useful in case the video needs to be created first and then the upload to be performed later.

Currently, it's not possible to use perform_upload_tus() method because it is private.