### PR TITLE
Unable to overwrite cache directory used in the TUS client

### DIFF
--- a/src/Vimeo/Upload/TusClient.php
+++ b/src/Vimeo/Upload/TusClient.php
@@ -1,9 +1,8 @@
 <?php
 
-
 namespace Vimeo\Upload;
 
-
+use TusPhp\Config;
 
 class TusClient extends \TusPhp\Tus\Client
 {
@@ -15,6 +14,18 @@ class TusClient extends \TusPhp\Tus\Client
     public function setUrl(string $url)
     {
         $this->url = $url;
+        return $this;
+    }
+
+    /**
+     * Sets the FileStore configuration
+     * @param string|array $config Configuration array, or a path to configuration file, e.g.: vendor/ankitpokhrel/tus-php/src/Config/client.php
+     * @return $this
+     */
+    public function setConfig($config)
+    {
+        Config::set($config, true);
+        $this->setCache('file');
         return $this;
     }
 }

--- a/src/Vimeo/Vimeo.php
+++ b/src/Vimeo/Vimeo.php
@@ -52,6 +52,9 @@ class Vimeo
     /** @var null|string */
     private $_access_token = null;
 
+    /** @var null|array */
+    private $_tus_config = null;
+
     /**
      * Creates the Vimeo library, and tracks the client and token information.
      *
@@ -191,6 +194,16 @@ class Vimeo
     public function setCURLOptions(array $curl_opts = array()): void
     {
         $this->_curl_opts = $curl_opts;
+    }
+
+    /**
+     * Sets custom TUS client FileStore configuration.
+     *
+     * @param array $config An associative array of TUS FileStore configuration.
+     */
+    public function setTUSConfig(array $config = array()): void
+    {
+        $this->_tus_config = $config;
     }
 
     /**
@@ -590,6 +603,7 @@ class Vimeo
         $chunk_size = $this->getTusUploadChunkSize($default_chunk_size, (int)$file_size);
 
         $client = new TusClient($base_url);
+        $client->setConfig($this->_tus_config);
         $client->setApiPath($api_path);
         $client->setKey($key)->file($file_path);
         $client->setUrl($url);


### PR DESCRIPTION
This PR contains changes that would allow to overwrite the TUS client FileStore cache directory path, which is used when uploading or replacing a video. This is necessary for the case when the original cache directory (`vendor/ankitpokhrel/tus-php/.cache`, specified in `vendor/ankitpokhrel/tus-php/Config/client.php`) location is not writable.