### PR TITLE
Accept null upload_link

### DIFF
--- a/src/Vimeo/Upload/TusClient.php
+++ b/src/Vimeo/Upload/TusClient.php
@@ -9,7 +9,7 @@ class TusClient extends \TusPhp\Tus\Client
 {
     /**
      * Sets the url for retrieving the TUS upload.
-     * @param string $url
+     * @param string|null $url
      * @return $this
      */
     public function setUrl(string $url)

--- a/src/Vimeo/Upload/TusClientFactory.php
+++ b/src/Vimeo/Upload/TusClientFactory.php
@@ -8,7 +8,7 @@ class TusClientFactory
 {
     /**
      * @param string $base_uri The fully qualified domain of the upload, ex: https://us-files.tus.vimeo.com
-     * @param string $url The fully qualified url of the upload, ex: https://us-files.tus.vimeo.com/files/vimeo-a1b2c3d4
+     * @param string|null $url The fully qualified url of the upload, ex: https://us-files.tus.vimeo.com/files/vimeo-a1b2c3d4
      * @return Client
      */
     public function getTusClient(string $base_uri, string $url) : Client


### PR DESCRIPTION
There are certain instances where `upload_link` is returned as null when performing an upload attempt, causing an error when setting the TusClient url. This PR adjusts the psalm annotation for the url param to accept a string or null value. 