### PR TITLE
PHP-8-Compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,17 @@
         }
     ],
     "minimum-stability": "stable",
+    "repositories": {
+        "ankitpokhrel/tus-php": {
+            "type": "git",
+            "url": "https://github.com/mestrega/tus-php.git"
+        }
+    },
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.1.0 || ^8.0",
         "ext-curl": "*",
         "ext-json":"*",
-        "ankitpokhrel/tus-php": "^v1.0.0 || ^v2.0.0"
+        "ankitpokhrel/tus-php": "dev-Feature/Make-Compat-With-EOL-D9"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
DO NOT MERGE IN. I am creating this so that others who might be experiencing this have something to work on while they are moving from PHP 7 to PHP 8 on Drupal 9 to prep for Drupal 10 migration. 

Please note, part of these changes require the forked repo for tus-php, which I have forked here: https://github.com/mestrega/tus-php.