### PR TITLE
Support for absolute URLs, HEAD request and public tus upload

### DIFF
--- a/src/Vimeo/Vimeo.php
+++ b/src/Vimeo/Vimeo.php
@@ -122,6 +122,9 @@ class Vimeo
                 }
 
                 $curl_url = (!$absoluteUrl ? self::ROOT_ENDPOINT : '') . $url . $query_component;
+                $curl_opts = array(
+                    CURLOPT_CUSTOMREQUEST => $method,
+                );
                 break;
 
             case 'POST':

--- a/src/Vimeo/Vimeo.php
+++ b/src/Vimeo/Vimeo.php
@@ -583,7 +583,7 @@ class Vimeo
      * @return string
      * @throws VimeoUploadException
      */
-    private function perform_upload_tus(string $file_path, $file_size, array $attempt): string
+    public function perform_upload_tus(string $file_path, $file_size, array $attempt): string
     {
         $default_chunk_size = (100 * 1024 * 1024); // 100 MB
 

--- a/src/Vimeo/Vimeo.php
+++ b/src/Vimeo/Vimeo.php
@@ -87,10 +87,11 @@ class Vimeo
      * @param string $method The HTTP Method of the request
      * @param bool $json_body
      * @param array $headers An array of HTTP headers to pass along with the request.
+     * @param bool $absoluteUrl
      * @return array This array contains three keys, 'status' is the status code, 'body' is an object representation of the json response body, and headers are an associated array of response headers
      * @throws VimeoRequestException
      */
-    public function request($url, $params = array(), $method = 'GET', $json_body = true, array $headers = array()): array
+    public function request($url, $params = array(), $method = 'GET', $json_body = true, array $headers = array(), bool $absoluteUrl = false): array
     {
         $headers = array_merge(array(
             'Accept' => self::VERSION_STRING,
@@ -120,7 +121,7 @@ class Vimeo
                     $query_component = '';
                 }
 
-                $curl_url = self::ROOT_ENDPOINT . $url . $query_component;
+                $curl_url = (!$absoluteUrl ? self::ROOT_ENDPOINT : '') . $url . $query_component;
                 break;
 
             case 'POST':
@@ -134,7 +135,7 @@ class Vimeo
                     $body = http_build_query($params, '', '&');
                 }
 
-                $curl_url = self::ROOT_ENDPOINT . $url;
+                $curl_url = (!$absoluteUrl ? self::ROOT_ENDPOINT : '') . $url;
                 $curl_opts = array(
                     CURLOPT_POST => true,
                     CURLOPT_CUSTOMREQUEST => $method,


### PR DESCRIPTION
Some requests (like TUS upload) require full URLs and the tus_upload function has been converted to public